### PR TITLE
export library for use by other packages

### DIFF
--- a/leg_detector/CMakeLists.txt
+++ b/leg_detector/CMakeLists.txt
@@ -39,6 +39,7 @@ include_directories(
 )
 
 catkin_package(INCLUDE_DIRS include
+  LIBRARIES leg_detector_lib
   CATKIN_DEPENDS people_msgs sensor_msgs std_msgs geometry_msgs visualization_msgs)
 
 ## Declare a cpp executable


### PR DESCRIPTION
The leg_detector_lib is being used by object_tracking but is not being exported with the catkin package definition.

We need to add this library to be defined/exported and it will be pulled in by the normal catkin/cmake variables.

The current setup breaks the isolated install builds.

@asaini89 